### PR TITLE
Fix buttons placement on addDocumentModal (for Region, Club profiles), in Legistation. #1406,#1405

### DIFF
--- a/src/pages/Club/AddDocumentModal/AddDocumentModal.less
+++ b/src/pages/Club/AddDocumentModal/AddDocumentModal.less
@@ -20,11 +20,6 @@
     .cardButton {
       margin-bottom: 1.2rem;
     }
-
-    .buttons {
-        margin-left: 7px;
-        margin-right: 0px;
-    }
   }
   
   @media (max-width: 575px) {

--- a/src/pages/Club/AddDocumentModal/AddDocumentModal.tsx
+++ b/src/pages/Club/AddDocumentModal/AddDocumentModal.tsx
@@ -213,10 +213,10 @@ const AddDocumentModal = (props: Props) => {
           <Row justify="end">
             <Col md={24} xs={24} >
               <Form.Item style={{ textAlign: "right" }}>
-                <Button className="buttons" key="back" onClick={handleCancel}>
+                <Button  key="back" onClick={handleCancel}>
                   Відмінити
                 </Button>
-                <Button className="buttons" type="primary" htmlType="submit" loading={buttonLoading} disabled={disabled}>
+                <Button style={{ marginLeft: "7px" }} type="primary" htmlType="submit" loading={buttonLoading} disabled={disabled}>
                   Опублікувати
                 </Button>
               </Form.Item>

--- a/src/pages/DecisionTable/FormAddDecision.module.css
+++ b/src/pages/DecisionTable/FormAddDecision.module.css
@@ -11,6 +11,13 @@
   display: flex;
 }
 
+.cardButtonDocuments {
+  display: flex;
+  width: 100%;
+  max-width: 370px;
+  justify-content:flex-end;
+}
+
 .selectField {
   max-width: 370px;
   min-width: 370px;

--- a/src/pages/Documents/FormAddDocument.tsx
+++ b/src/pages/Documents/FormAddDocument.tsx
@@ -10,7 +10,6 @@ import {
   Col,
 } from "antd";
 import { InboxOutlined } from "@ant-design/icons";
-
 import documentsApi, {
   TypePostParser
 } from "../../api/documentsApi";
@@ -275,7 +274,7 @@ const FormAddDocument: React.FC<FormAddDocumentsProps> = (props: any) => {
               {fileData.FileAsBase64 !== null && (
                 <div>
                   <Button
-                    className={formclasses.cardButton}
+                    className={formclasses.cardButtonDocuments}
                     onClick={() => {
                       setFileData({ FileAsBase64: null, FileName: null });
                       notificationLogic("success", successfulDeleteAction("Файл"));

--- a/src/pages/Regions/AddDocModal.tsx
+++ b/src/pages/Regions/AddDocModal.tsx
@@ -171,10 +171,10 @@ const AddDocumentModal = (props: Props) => {
             <Row justify="end">
               <Col md={24} xs={24}>
                 <Form.Item style={{ textAlign: "right" }} className="cancelConfirmButtons">
-                  <Button key="back" className="buttons" onClick={handleCancel}>
+                  <Button key="back" onClick={handleCancel}>
                     Відмінити
                   </Button>
-                    <Button type="primary" className="buttons" loading={buttonLoading} disabled={disabled} htmlType="submit">
+                    <Button style={{ marginLeft: "7px" }} type="primary" loading={buttonLoading} disabled={disabled} htmlType="submit">
                       Опублікувати
                     </Button>
                 </Form.Item>

--- a/src/pages/Regions/AddDocumentModal.less
+++ b/src/pages/Regions/AddDocumentModal.less
@@ -20,11 +20,6 @@
   .cardButton {
     margin-bottom: 1.2rem;
   }
-
-  .buttons {
-    margin-left: 7px;
-    margin-right: 0px;
-  }
 }
 
 @media (max-width: 575px) {


### PR DESCRIPTION
[Decision] button 'Видалити файл' isn't aligned #1406

[Hovel documentation] buttons are not aligned #1405

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
