### PR TITLE
Fixed [Users table] The Hovel Admin shouldn't see the 'Додати ступінь…

### DIFF
--- a/src/pages/UserTable/DropDownUserTable.tsx
+++ b/src/pages/UserTable/DropDownUserTable.tsx
@@ -126,10 +126,6 @@ const DropDown = (props: Props) => {
         && currentUser?.regionId == user?.regionId;
       const isCurrentUserRegionHeadDeputy = roles.includes(Roles.OkrugaHeadDeputy) 
         && currentUser?.regionId == user?.regionId;
-      const isCurrentUserKurinHeadDeputy = roles.includes(Roles.KurinHeadDeputy) 
-        && currentUser?.clubId == user?.clubId;
-      const isCurrentUserKurinHead = roles.includes(Roles.KurinHead) 
-        && currentUser?.clubId == user?.clubId;
       const isUserCityHead = roles.includes(Roles.CityHead) 
         && currentUser?.cityId == user?.cityId;
       const isUserCityHeadDeputy = roles.includes(Roles.CityHeadDeputy) 
@@ -139,8 +135,6 @@ const DropDown = (props: Props) => {
       isCurrentUserGoverningBodyHead ||      
       isCurrentUserRegionHead ||      
       isCurrentUserRegionHeadDeputy ||
-      isCurrentUserKurinHeadDeputy ||
-      isCurrentUserKurinHead ||
       isUserCityHead ||
       isUserCityHeadDeputy;
     });
@@ -152,10 +146,6 @@ const DropDown = (props: Props) => {
         && currentUser?.regionId == user?.regionId;
       const isCurrentUserRegionHeadDeputy = roles.includes(Roles.OkrugaHeadDeputy) 
         && currentUser?.regionId == user?.regionId;
-      const isCurrentUserKurinHeadDeputy = roles.includes(Roles.KurinHeadDeputy) 
-        && currentUser?.clubId == user?.clubId;
-      const isCurrentUserKurinHead = roles.includes(Roles.KurinHead) 
-        && currentUser?.clubId == user?.clubId;
       const isUserCityHead = roles.includes(Roles.CityHead) 
         && currentUser?.cityId == user?.cityId;
       const isUserCityHeadDeputy = roles.includes(Roles.CityHeadDeputy) 
@@ -165,8 +155,6 @@ const DropDown = (props: Props) => {
       isCurrentUserGoverningBodyHead ||      
       isCurrentUserRegionHead ||      
       isCurrentUserRegionHeadDeputy ||
-      isCurrentUserKurinHeadDeputy ||
-      isCurrentUserKurinHead ||
       isUserCityHead ||
       isUserCityHeadDeputy;
     });


### PR DESCRIPTION
…' and 'Поточний стан користувача' sections at the menu after right-clicking on the member of the Hovel, the Admin of which he is #1654

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
