### PR TITLE
UserTable visulas

### DIFF
--- a/src/pages/UserTable/ColumnsForUserTable.tsx
+++ b/src/pages/UserTable/ColumnsForUserTable.tsx
@@ -159,9 +159,6 @@ const ColumnsForUserTable = (props: Props): any[] => {
       title: (
         <Row className="tableHeader">
           <Col className="col-title">№</Col>
-          <Col className="col-value">
-            <SortDirection sort={1} />
-          </Col>
         </Row>
       ),
       render: (text, record, index) => {

--- a/src/pages/UserTable/UserTable.tsx
+++ b/src/pages/UserTable/UserTable.tsx
@@ -56,7 +56,7 @@ const UsersTable = () => {
   const [clubs, setClubs] = useState<any>();
   const [degrees, setDegrees] = useState<any>();
   const [searchData, setSearchData] = useState<string>("");
-  const [sortKey, setSortKey] = useState<number>(1);
+  const [sortKey, setSortKey] = useState<number>(0);
   const [filter, setFilter] = useState<any[]>([]);
   const [dynamicCities, setDynamicCities] = useState<any[]>([]);
   const [dynamicRegions, setDynamicRegions] = useState<any[]>([]);


### PR DESCRIPTION
Nubmers in table aren't sortable, because they are not a part of user entity from backend. So, SortDirection buttons for № column have been removed to avoid confusion.

Fixed default column background colour (was name column, but it wasn't sorted by name)

