### PR TITLE
inactive-precaution-change

### DIFF
--- a/src/pages/Precaution/PrecautionTable/columns.tsx
+++ b/src/pages/Precaution/PrecautionTable/columns.tsx
@@ -73,7 +73,7 @@ const columns: ColumnsType<UserPrecautionTableItem> = [
     render: (endDate: Date, record: any) => {
       return record.isActive === true
         ? moment.utc(endDate.toLocaleString()).local().format("DD.MM.YYYY")
-        : "не активна";
+        : moment.utc(endDate.toLocaleString()).local().format("DD.MM.YYYY (неактивна)");
     },
     sorter: true,
     sortDirections: ["ascend", "descend"] as SortOrder[],


### PR DESCRIPTION
Show inactive closing date in Precaution Table, but note that it is inactive in (brackets)

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

 ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
