### PR TITLE
There was no opportunity to load and download files with dots in name

### DIFF
--- a/src/api/blankApi.tsx
+++ b/src/api/blankApi.tsx
@@ -91,7 +91,7 @@ export const openBiographyFile = async (fileBlob: string, fileName: string) => {
   const response = await (
     await api.get(`Blanks/BiographyDocumentBase64/${fileBlob}`, fileBlob)
   ).data;
-  const format = fileName.split(".")[1];
+  const format = fileName.split(".").pop()!;
   const base64 = response.split(",")[1];
   await openFile(base64, format);
 };
@@ -119,7 +119,7 @@ export const openExtractFromUPUFile = async (
   const response = await (
     await api.get(`Blanks/ExtractFromUPUDocumentBase64/${fileBlob}`, fileBlob)
   ).data;
-  const format = fileName.split(".")[1];
+  const format = fileName.split(".").pop()!;
   const base64 = response.split(",")[1];
   await openFile(base64, format);
 };
@@ -131,7 +131,7 @@ export const openAchievemetFile = async (
   const response = await (
     await api.get(`Blanks/AchievementDocumentBase64/${fileBlob}`, fileBlob)
   ).data;
-  const format = fileName.split(".")[1];
+  const format = fileName.split(".").pop()!;
   const base64 = response.split(",")[1];
   await openFile(base64, format);
 };

--- a/src/pages/userPage/Blanks/Blanks.tsx
+++ b/src/pages/userPage/Blanks/Blanks.tsx
@@ -134,7 +134,7 @@ export const Blanks = () => {
     await openExtractFromUPUFile(fileBlob, fileName);
   };
   const getFormat = (fileName: string) => {
-    if (fileName != undefined) return fileName.split(".")[1];
+    if (fileName != undefined) return fileName.split(".").pop()!;
   };
   useEffect(() => {
     fetchData();
@@ -201,13 +201,13 @@ export const Blanks = () => {
                   key={document.id}
                 >
                   <div>
-                    {document.blobName.split(".")[1] === "pdf" && (
+                    {document.blobName.split(".").pop()! === "pdf" && (
                       <FilePdfOutlined className={classes.documentIcon} />
                     )}
                     {"jpg, jpeg, png".includes(
-                      document.blobName.split(".")[1]
+                      document.blobName.split(".").pop()!
                     ) && <FileImageOutlined className={classes.documentIcon} />}
-                    {"docx, doc".includes(document.blobName.split(".")[1]) && (
+                    {"docx, doc".includes(document.blobName.split(".").pop()!) && (
                       <FileTextOutlined className={classes.documentIcon} />
                     )}
                     {document.fileName?.length > fileNameMaxLength ? (
@@ -309,14 +309,14 @@ export const Blanks = () => {
                   key={document.id}
                 >
                   <div>
-                    {extractUPU.blobName.split(".")[1] === "pdf" && (
+                    {extractUPU.blobName.split(".").pop()! === "pdf" && (
                       <FilePdfOutlined className={classes.documentIcon} />
                     )}
                     {"jpg, jpeg, png".includes(
-                      extractUPU.blobName.split(".")[1]
+                      extractUPU.blobName.split(".").pop()!
                     ) && <FileImageOutlined className={classes.documentIcon} />}
                     {"docx, doc".includes(
-                      extractUPU.blobName.split(".")[1]
+                      extractUPU.blobName.split(".").pop()!
                     ) && <FileTextOutlined className={classes.documentIcon} />}
                     {extractUPU.fileName?.length > fileNameMaxLength ? (
                       <Tooltip

--- a/src/pages/userPage/Blanks/UserAchievements/ListOfAchievementsModal.tsx
+++ b/src/pages/userPage/Blanks/UserAchievements/ListOfAchievementsModal.tsx
@@ -148,13 +148,13 @@ const ListOfAchievementsModal = (props: Props) => {
             renderItem={(item) => (
               <List.Item
                 actions={
-                  item.fileName.split(".")[1] !== "doc" &&
-                  item.fileName.split(".")[1] !== "docx"
+                  item.fileName.split(".").pop()! !== "doc" &&
+                  item.fileName.split(".").pop()! !== "docx"
                     ? getListActions(item)
                     : getListActions(item).splice(0, 1)
                 }
               >
-                {item.blobName.split(".")[1] === "pdf" ? (
+                {item.blobName.split(".").pop()! === "pdf" ? (
                   <FilePdfOutlined className={classes.fileIcon} />
                 ) : (
                   <FileImageOutlined className={classes.fileIcon} />


### PR DESCRIPTION
I wrote '!' after pop() because file always has dot and extension after it

Closes https://github.com/ita-social-projects/EPlast/issues/2702

## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
