### PR TITLE
Fix-#2807. No distance between word 'Контакти' and information icon

### DIFF
--- a/src/pages/Contacts/Contacts.module.css
+++ b/src/pages/Contacts/Contacts.module.css
@@ -4,7 +4,8 @@
 }
 
 #InfoOut{
-  font-size: 32px;
+  font-size: 24px;
+  margin: 5px 20px 0 0;
 }
 
 #addonElement{


### PR DESCRIPTION
closes https://github.com/ita-social-projects/EPlast/issues/2807

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
