### PR TITLE
2742 - Fix 'Add certificate' button appears in another user course page

### DIFF
--- a/src/pages/userPage/Blanks/Blanks.module.css
+++ b/src/pages/userPage/Blanks/Blanks.module.css
@@ -56,6 +56,13 @@
     font-size: 28px; 
     color: #3C5438
 }
+.courseInfoBlock{
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+}
 
 .wrapper2,
 .wrapper3,
@@ -79,7 +86,6 @@
     flex-direction: column;
     align-items: center;
     text-align: center;
-    padding-top: 20px;
 }
 .wrapper2:hover,
 .wrapper3:hover,

--- a/src/pages/userPage/Blanks/Blanks.tsx
+++ b/src/pages/userPage/Blanks/Blanks.tsx
@@ -500,11 +500,11 @@ export const Blanks = () => {
         userToken={userToken}
         visibleModal={visibleListAchievementModal}
         setVisibleModal={setVisibleListAchievementModal}
-        hasAccess={
+        hasAccessToSee={
           userProfileAccess["CanSeeUserDistinction"] ||
           userToken.nameid === userId
         }
-        hasAccessToSeeAndDownload={
+        hasAccessToDownload={
           userProfileAccess["CanDownloadUserDistinction"] ||
           userToken.nameid === userId
         }

--- a/src/pages/userPage/Blanks/UserAchievements/ListOfAchievementsModal.tsx
+++ b/src/pages/userPage/Blanks/UserAchievements/ListOfAchievementsModal.tsx
@@ -26,10 +26,10 @@ const fileNameMaxLength = 47;
 interface Props {
   visibleModal: boolean;
   setVisibleModal: (visibleModal: boolean) => void;
-  hasAccess?: boolean;
-  hasAccessToSeeAndDownload?: boolean;
+  hasAccessToSee?: boolean;
+  hasAccessToDownload?: boolean;
   hasAccessToDelete?: boolean;
-  userToken: any;
+  userToken: {nameid: string};
   courseId?: number; 
 }
 
@@ -45,6 +45,7 @@ const ListOfAchievementsModal = (props: Props) => {
   const [isEmpty, setIsEmpty] = useState(false);
   
   const handleCancel = () => {
+    props.setVisibleModal(false);
     setLoadingMore({ loading: false, hasMore: true });
     setIsEmpty(false);
     setPageNumber(0);
@@ -92,8 +93,7 @@ const ListOfAchievementsModal = (props: Props) => {
 
   const getActions = (blackDocumentItem: BlankDocument, isNotDocx = true) => {
     const actions: JSX.Element[] = [];
-    if (props.hasAccessToSeeAndDownload) {
-      if (isNotDocx) {
+    if (props.hasAccessToDownload && isNotDocx) {
         actions.push(
           <EyeOutlined
             className={classes.reviewIcon}
@@ -102,7 +102,8 @@ const ListOfAchievementsModal = (props: Props) => {
             }
           />
         );
-      }
+    }
+    if (props.hasAccessToSee) {
       actions.push(
         <DownloadOutlined
           className={classes.downloadIcon}
@@ -132,7 +133,7 @@ const ListOfAchievementsModal = (props: Props) => {
   }
 
   useEffect(() => {
-    if (achievements.length === 0) {
+    if (achievements.length === 0 && userId === props.userToken.nameid) {
       props.setVisibleModal(false);
       setLoadingMore({ loading: false, hasMore: true });
       setIsEmpty(false);

--- a/src/pages/userPage/personalData/Courses.tsx
+++ b/src/pages/userPage/personalData/Courses.tsx
@@ -13,14 +13,13 @@ import { getAllCourseByUserId } from "../../../api/courseApi";
 import classes from "../Blanks/Blanks.module.css";
 
 export const Courses: React.FC = () => {
+  const [userToken, setUserToken] = useState<{nameid: string}>({nameid: ''});
   const [visible, setVisible] = useState(false);
   const [visibleAchievementModal, setVisibleAchievementModal] = useState(false);
   const [visibleListModal, setVisibleListModal] = useState(false);
   const [isDataLoaded, setDataLoaded] = useState(false);
   const [courseId, setCourseId] = useState(0);
   const [courses, setCourses] = useState<Course[]>([]);
-
-  let userToken: { nameid: string } = { nameid: "" };
 
   const { userId } = useParams<{ userId: string }>();
   const {
@@ -31,8 +30,8 @@ export const Courses: React.FC = () => {
   } = useContext(PersonalDataContext);
 
   const fetchData = async () => {
-    userToken = jwt(AuthLocalStorage.getToken() ?? "");
-    const courses = await getAllCourseByUserId(activeUserId);
+    setUserToken(jwt(AuthLocalStorage.getToken() ?? ""));
+    const courses = await getAllCourseByUserId(userProfile?.user.id);
     setCourses(courses.data);
     setDataLoaded(true);
   };
@@ -63,13 +62,13 @@ export const Courses: React.FC = () => {
       </div>
     )
     : isDataLoaded ? (
-      <div className={classes.wrapper6} style={{margin: 0}}>
+      <div className={[classes.wrapper6, classes.courseInfoBlock].join(' ')}>
         {
           courses.map(sectItem =>
             (sectItem.isFinishedByUser === false && 
-            (userProfile?.shortUser?.id === activeUserId || userProfile?.shortUser === null)) ? (
+            (userProfile?.user.id === activeUserId)) ? (
               <Col key={sectItem.id}>
-                <Title level={2} title={sectItem.name} />
+                <Title level={2}>{sectItem.name}</Title>
                 <p>
                   <strong>{userProfile?.user.firstName}</strong>, пройдіть курс для продовження співпраці з нами
                 </p>
@@ -87,20 +86,26 @@ export const Courses: React.FC = () => {
                 </div>
               </Col>
             ) : (
-              <Col style={{ marginTop: "64px" }}>
-                <Title level={2}> {sectItem.name}</Title>
-                <p>
-                  Курс {sectItem.name} пройдено, сертифікат можна переглянути в
-                  <Button style={{padding: "0 0 0 4px"}}
-                    type="link" 
-                    onClick={() => {
-                      setVisibleListModal(true);
-                      setCourseId(sectItem.id)
-                    }}
-                  >
-                    <b>Досягненнях</b>
-                  </Button>
-                </p>
+              <Col>
+                <Title level={2}>{sectItem.name}</Title>
+                {
+                  (sectItem.isFinishedByUser) ? (
+                    <p>
+                      Курс пройдено, сертифікат можна переглянути в
+                      <Button style={{padding: "0 0 0 4px"}}
+                        type="link" 
+                        onClick={() => {
+                          setVisibleListModal(true);
+                          setCourseId(sectItem.id)
+                        }}
+                      >
+                        <b>Досягненнях</b>
+                      </Button>
+                    </p>
+                  ) : (
+                    <p>Курс не пройдено</p>
+                  )
+                }
               </Col>
             )
           )
@@ -134,16 +139,16 @@ export const Courses: React.FC = () => {
           userToken={userToken}
           visibleModal={visibleListModal}
           setVisibleModal={setVisibleListModal}
-          hasAccess={
-            userProfileAccess.CanSeeUserDistinction
+          hasAccessToSee={
+            userProfileAccess["CanSeeUserDistinction"]
             || userToken.nameid === userId
           }
-          hasAccessToSeeAndDownload={
-            userProfileAccess.CanDownloadUserDistinction
+          hasAccessToDownload={
+            userProfileAccess["CanDownloadUserDistinction"]
             || userToken.nameid === userId
           }
           hasAccessToDelete={
-            userProfileAccess.CanDeleteUserDistinction
+            userProfileAccess["CanDeleteUserDistinction"]
             || userToken.nameid === userId
           }
         />


### PR DESCRIPTION
Fix:
1. If user go to another user page he cannot see 'Add certificate' button
2. Info dispayed about whether the user end course or not
3. Update course block styles

Closes https://github.com/ita-social-projects/EPlast/issues/2742

## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
